### PR TITLE
Fix for windows build

### DIFF
--- a/clean.js
+++ b/clean.js
@@ -1,0 +1,20 @@
+/** 
+ * Part of the build script because windows doesn't have rm -rf and npm doesn't have conditionals
+*/
+const exec = require('child_process').exec;
+const os = require('os');
+function done(error, stdout, stderr) {
+  if (error) {
+    console.error(`exec error: ${error}`);
+    return;
+  }
+  console.log(`stdout: ${stdout}`);
+  console.log(`stderr: ${stderr}`);
+  console.log("All done cleaning dist");
+}
+
+if(os.platform() == "win32"){
+    exec("if exist \"dist\" rd /S/Q dist",done);
+}else{
+     exec("rm -rf ./dist/*",done);
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:ecc": "mocha --compilers js:babel-core/register ./test/ecc --recursive",
     "test:serializer": "mocha --compilers js:babel-core/register ./test/serializer --recursive",
     "test:watch": "npm test -- --watch",
-    "clean": "rm -rf ./dist/*",
+    "clean" : "node clean.js",
     "prebuild": "npm run clean",
     "build": "babel lib --presets babel-preset-es2015 --out-dir dist",
     "prepublish": "npm run build",


### PR DESCRIPTION
It wouldn't build on windows because npm clean was calling rm -rf.
I added a clean.js file that checks the os and runs rd /s/q on win32
